### PR TITLE
fix docker trojan-panel-network create bug

### DIFF
--- a/install_script.sh
+++ b/install_script.sh
@@ -326,6 +326,12 @@ function installDocker() {
       exit 0
     fi
   else
+    if [[ -n $(docker network ls | grep "trojan-panel-network") ]]; then
+    echo "Trojan-panel-network created"
+    else
+    echo "Create Trojan-panel-network"
+    docker network create trojan-panel-network
+    fi  
     echoContent skyBlue "---> 你已经安装了Docker"
   fi
 }


### PR DESCRIPTION
修复因服务器已安装或者自行手动安装过docker情况下，可能出现trojan-panel-network未创建，导致容器无法互联的bug